### PR TITLE
Add Docker support to semantic-search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:18.04
+
+# Install system dependencies and Python packages
+RUN apt-get update -y && \
+    apt-get -y install libimage-exiftool-perl
+
+FROM continuumio/miniconda3
+
+COPY . /src
+WORKDIR /src
+
+COPY environment.yml .
+COPY config.yml .
+
+RUN conda env create -f environment.yml
+
+EXPOSE 5000
+COPY . .
+# CMD python3 -m main -c=config.yml -vv
+CMD ["conda", "run", "--name", "semantic-search", "python3", "-m", "main", "-c=config.yml", "-vv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:18.04 AS os-dependencies
+FROM continuumio/miniconda3:latest
 
 # Install system dependencies.
 RUN apt-get update -y && \
     apt-get -y install libimage-exiftool-perl
-
-FROM continuumio/miniconda3:4.10.3p0-alpine
-
-# From the previous image, copy exiftool into this image.
-COPY --from=os-dependencies /usr/bin/exiftool /usr/bin/exiftool
 
 # Add the local code to the /app directory and set it to be the working directory.
 # Since we mount the /app directory as a volume in docker-compose.yml, this

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,25 @@ FROM ubuntu:18.04
 RUN apt-get update -y && \
     apt-get -y install libimage-exiftool-perl
 
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:4.10.3p0-alpine
 
-COPY . /src
-WORKDIR /src
+COPY . .
 
-COPY environment.yml .
-COPY config.yml .
+# Get the arguments from the docker-compose environment
+ARG PORT
+EXPOSE ${PORT}
 
+# This allows us to use the arguments during runtime
 RUN conda env create -f environment.yml
 
-EXPOSE 5000
-COPY . .
-# CMD python3 -m main -c=config.yml -vv
-CMD ["conda", "run", "--name", "semantic-search", "python3", "-m", "main", "-c=config.yml", "-vv"]
+# Use the conda environment we created to run the application.
+# The docker execution process run conda activate semantic-search, since the lifetime of the environment would only be for the single command.
+# Instead, we'll use the conda run to run the application.
+# Use 0.0.0.0 to explicitly set the host ip for the service on the container. https://pythonspeed.com/articles/docker-connection-refused/
+# Use sh -c to start a shell in order to use environment variables in CMD.
+ENTRYPOINT ["conda", "run", "--no-capture-output", "--name", "semantic-search", \
+    "python3", "-m", "src.main"]
+
+    # "python3", "-m", "src.main", "-c=${CONFIG_FILE}", "-vv" ,"--host=${HOST}, "--port=${PORT}"]
+
+# CMD ["sh", "-c", "echo ${CONFIG_FILE}", "echo ${HOST}", "echo ${PORT}"]

--- a/README.org
+++ b/README.org
@@ -5,32 +5,52 @@
 
   All data is processed locally. User can interface with semantic-search app via [[./src/interface/emacs/semantic-search.el][Emacs]], API or Commandline
 
-** Dependencies
-   - Python3
-   - [[https://docs.conda.io/en/latest/miniconda.html#latest-miniconda-installer-links][Miniconda]]
+** Setup
 
-** Install
-   #+begin_src shell
-   git clone https://github.com/debanjum/semantic-search && cd semantic-search
-   conda env create -f environment.yml
-   conda activate semantic-search
-   #+end_src
+*** Setup using Docker
 
-*** Install Environmental Dependencies
-   #+begin_src shell
-   sudo apt-get -y install libimage-exiftool-perl
-   #+end_src
+**** 1. Clone Repository
+     #+begin_src shell
+       git clone https://github.com/debanjum/semantic-search && cd semantic-search
+     #+end_src
 
-** Configure
-   Configure application search types and their underlying data source/files in ~sample_config.yml~
-   Use the ~sample_config.yml~ as reference
+**** 2. Configure
+     Add Content Directories for Semantic Search to Docker-Compose
+     Update [[./docker-compose.yml][docker-compose.yml]] to mount your images, org-mode notes, ledger/beancount directories
+     If required, edit config settings in [[./docker_sample_config.yml][docker_sample_config.yml]].
 
-** Run
-   Load ML model, generate embeddings and expose API to query notes, images, transactions etc specified in config YAML
+**** 3. Run
+     #+begin_src shell
+     docker-compose up -d
+     #+end_src
 
-   #+begin_src shell
-   python3 -m src.main -c=sample_config.yml -vv
-   #+end_src
+*** Setup on Local Machine
+
+**** 1. Install Dependencies
+     1. Install Python3 [Required[
+     2. [[https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html][Install Conda]] [Required]
+     3. Install Exiftool [Optional]
+        #+begin_src shell
+        sudo apt-get -y install libimage-exiftool-perl
+        #+end_src
+
+**** 2. Install Semantic Search
+       #+begin_src shell
+       git clone https://github.com/debanjum/semantic-search && cd semantic-search
+       conda env create -f environment.yml
+       conda activate semantic-search
+       #+end_src
+
+**** 3. Configure
+     Configure application search types and their underlying data source/files in ~sample_config.yml~
+     Use the ~sample_config.yml~ as reference
+
+**** 4. Run
+     Load ML model, generate embeddings and expose API to query notes, images, transactions etc specified in config YAML
+
+     #+begin_src shell
+     python3 -m src.main -c=sample_config.yml -vv
+     #+end_src
 
 ** Use
    - *Semantic Search via Emacs*
@@ -39,16 +59,26 @@
 
    - *Semantic Search via API*
      - Query: ~GET~ [[http://localhost:8000/search?q=%22what%20is%20the%20meaning%20of%20life%22][http://localhost:8000/search?q="What is the meaning of life"&t=notes]]
-     - Regenerate Embeddings: ~GET~ [[http://localhost:8000/regenerate][http://localhost:8000/regenerate?t=image]]
+     - Regenerate Embeddings: ~GET~ [[http://localhost:8000/regenerate][http://localhost:8000/regenerate]]
      - [[http://localhost:8000/docs][Semantic Search API Docs]]
 
+   - *UI to Edit Config*
+     - [[https://localhost:8000/ui][Config UI]]
+
 ** Upgrade
-   #+begin_src shell
-     cd semantic-search
-     git pull origin master
-     conda env update -f environment.yml
-     conda activate semantic-search
-   #+end_src
+
+*** Using Docker
+    #+begin_src shell
+      docker-compose up
+    #+end_src
+
+*** On Local Machine
+    #+begin_src shell
+      cd semantic-search
+      git pull origin master
+      conda env update -f environment.yml
+      conda activate semantic-search
+    #+end_src
 
 ** Acknowledgments
    - [[https://huggingface.co/sentence-transformers/msmarco-MiniLM-L-6-v3][MiniLM Model]] for Asymmetric Text Search. See [[https://www.sbert.net/examples/applications/retrieve_rerank/README.html][SBert Documentation]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,30 @@ services:
   server:
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         - PORT=8000
     ports:
+      # If changing the local port (left hand side), no other changes required.
+      # If changing the remote port (right hand side), 
+      #   change the port in the args in the build section, 
+      #   as well as the port in the command section to match
       - "8000:8000"
+    working_dir: /app
     volumes:
-      - .:/code
-      - /home/saba/notes/:/data/notes/
-      - /home/saba/embeddings/:/data/generated/
-      - /home/saba/images/:/data/images/
-      - /home/saba/ledger/:/data/ledger/
-      - /home/saba/music/:/data/music/
+      - .:/app
+      # These mounted volumes hold the raw data that should be indexed for search. 
+      # The path in your local directory (left hand side)
+      #   points to the files you want to index.
+      # The path of the mounted directory (right hand side),
+      #   must match the path prefix in your config file.
+      - /path/to/notes/:/data/notes/
+      - /path/to/photos/:/data/images/
+      - /path/to/ledger/:/data/ledger/
+      - /path/to/music/:/data/music/
+      # It's ok if you don't have existing embeddings. 
+      # Leave the line as is - an empty volume will be created if it doesn't exist.
+      - /path/to/embeddings/:/data/generated/
+
+    # Use 0.0.0.0 to explicitly set the host ip for the service on the container. https://pythonspeed.com/articles/docker-connection-refused/
     command: --host="0.0.0.0" --port=8000 -c=docker_sample_config.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+services:
+  web:
+    build:
+      context: .
+      args:
+        - PORT=8000
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/code
+      - /home/saba/notes/:/data/notes/
+      - /home/saba/embeddings/:/data/generated/
+      - /home/saba/images/:/data/images/
+      - /home/saba/ledger/:/data/ledger/
+      - /home/saba/music/:/data/music/
+    command: --host="0.0.0.0" --port=8000 -c=docker_sample_config.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,13 @@ services:
       #   points to the files you want to index.
       # The path of the mounted directory (right hand side),
       #   must match the path prefix in your config file.
-      - /path/to/notes/:/data/notes/
-      - /path/to/photos/:/data/images/
-      - /path/to/ledger/:/data/ledger/
-      - /path/to/music/:/data/music/
+      - ./tests/data/:/data/notes/
+      - ./tests/data/:/data/images/
+      - ./tests/data/:/data/ledger/
+      - ./tests/data/:/data/music/
       # It's ok if you don't have existing embeddings. 
-      # Leave the line as is - an empty volume will be created if it doesn't exist.
-      - /path/to/embeddings/:/data/generated/
+      # You can set this volume to point to an empty folder.
+      - ./tests/data/:/data/generated/
 
     # Use 0.0.0.0 to explicitly set the host ip for the service on the container. https://pythonspeed.com/articles/docker-connection-refused/
-    command: --host="0.0.0.0" --port=8000 -c=docker_sample_config.yml
+    command: --host="0.0.0.0" --port=8000 -c=docker_sample_config.yml -vv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.9"
 services:
-  web:
+  server:
     build:
       context: .
       args:

--- a/docker_sample_config.yml
+++ b/docker_sample_config.yml
@@ -1,4 +1,7 @@
 content-type:
+  # The /data/folder/ prefix to the folders is here because this is 
+  # the directory to which the local files are copied in the docker-compose.
+  # If changing, the docker-compose volumes should also be changed to match.
   org:
     input-files: null
     input-filter: "/data/notes/*.org"
@@ -6,22 +9,22 @@ content-type:
     embeddings-file: "/data/generated/.note_embeddings.pt"
 
   ledger:
-    # input-files: null
-    # input-filter: /data/ledger/*.beancount
-    # compressed-jsonl: /data/generated/.transactions.jsonl.gz
-    # embeddings-file: /data/generated/.transaction_embeddings.pt
+    input-files: null
+    input-filter: /data/ledger/*.beancount
+    compressed-jsonl: /data/generated/.transactions.jsonl.gz
+    embeddings-file: /data/generated/.transaction_embeddings.pt
 
   image:
-    # input-directory: "/data/images/"
-    # embeddings-file: "/data/generated/.image_embeddings.pt"
-    # batch-size: 50
-    # use-xmp-metadata: "no"
+    input-directory: "/data/images/"
+    embeddings-file: "/data/generated/.image_embeddings.pt"
+    batch-size: 50
+    use-xmp-metadata: "no"
 
   music:
-    # input-files: null
-    # input-filter: "/data/music/*.org"
-    # compressed-jsonl: "/data/generated/.songs.jsonl.gz"
-    # embeddings-file: "/data/generated/.song_embeddings.pt"
+    input-files: null
+    input-filter: "/data/music/*.org"
+    compressed-jsonl: "/data/generated/.songs.jsonl.gz"
+    embeddings-file: "/data/generated/.song_embeddings.pt"
 
 search-type:
   symmetric:

--- a/docker_sample_config.yml
+++ b/docker_sample_config.yml
@@ -18,7 +18,7 @@ content-type:
     input-directory: "/data/images/"
     embeddings-file: "/data/generated/.image_embeddings.pt"
     batch-size: 50
-    use-xmp-metadata: "no"
+    use-xmp-metadata: true
 
   music:
     input-files: null

--- a/docker_sample_config.yml
+++ b/docker_sample_config.yml
@@ -1,0 +1,44 @@
+content-type:
+  org:
+    input-files: null
+    input-filter: "/data/notes/*.org"
+    compressed-jsonl: "/data/generated/.notes.json.gz"
+    embeddings-file: "/data/generated/.note_embeddings.pt"
+
+  ledger:
+    # input-files: null
+    # input-filter: /data/ledger/*.beancount
+    # compressed-jsonl: /data/generated/.transactions.jsonl.gz
+    # embeddings-file: /data/generated/.transaction_embeddings.pt
+
+  image:
+    # input-directory: "/data/images/"
+    # embeddings-file: "/data/generated/.image_embeddings.pt"
+    # batch-size: 50
+    # use-xmp-metadata: "no"
+
+  music:
+    # input-files: null
+    # input-filter: "/data/music/*.org"
+    # compressed-jsonl: "/data/generated/.songs.jsonl.gz"
+    # embeddings-file: "/data/generated/.song_embeddings.pt"
+
+search-type:
+  symmetric:
+    encoder: "sentence-transformers/paraphrase-MiniLM-L6-v2"
+    cross-encoder: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    model_directory: "/data/models/.symmetric"
+
+  asymmetric:
+    encoder: "sentence-transformers/msmarco-MiniLM-L-6-v3"
+    cross-encoder: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    model_directory: "/data/models/.asymmetric"
+
+  image:
+    encoder: "clip-ViT-B-32"
+    model_directory: "/data/models/.image_encoder"
+
+processor:
+  conversation:
+    openai-api-key: null
+    conversation-logfile: "/data/conversation/.conversation_logs.json"

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -15,7 +15,7 @@ content-type:
     input-directory: "tests/data"
     embeddings-file: "tests/data/.image_embeddings.pt"
     batch-size: 50
-    use-xmp-metadata: "no"
+    use-xmp-metadata: false
 
   music:
     input-files: ["tests/data/music.org"]

--- a/src/utils/rawconfig.py
+++ b/src/utils/rawconfig.py
@@ -20,7 +20,7 @@ class TextContentConfig(ConfigBase):
     embeddings_file: Optional[Path]
 
 class ImageContentConfig(ConfigBase):
-    use_xmp_metadata: Optional[str]
+    use_xmp_metadata: Optional[bool]
     batch_size: Optional[int]
     input_directory: Optional[Path]
     input_filter: Optional[str]


### PR DESCRIPTION
## Add Docker support
- Add a Dockerfile which builds from the `continuumio/miniconda3` image
   - Installs system-level dependencies (such as exiftool)
   - Performs Conda environment setup required to run the semantic-search application
- Add a docker-compose.yml
   - Exposes application on port 8000 and passes the program arguments (e.g., `port`, `host`, `config`)
   - Mounts the files to be indexed into volumes in the Docker image 
- Add relevant comments for documentation and rationale for why the files are setup in the way they are

Tested locally. To run:
- Checkout the branch and modify the file paths to match your local directories in `docker-compose.yml`
- Run `docker-compose up` from the root directory
- The application should be hosted on http://localhost:8000/ and can be run as usual

Closes #20

**NOTE**: I haven't figured out how to cache the Conda environment between builds, so building the image takes like 20-30 minutes (every time). You can make changes to `docker-compose.yml` and `docker_sample_config.yml` without having to rebuild.

## Bug fix
- Fixes a bug in the `rawconfig` specification which was setting the `use_xmp_metadata` field in the image search config to be a `str`, rather than `bool`. Update relevant configs.

Closes #22

## Update README.org
- Add instructions for running using Docker.