### PR TITLE
Run Explicit Filter on Entries, Embeddings before Semantic Search for Query

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -58,17 +58,17 @@ def search(q: str, n: Optional[int] = 5, t: Optional[SearchType] = None):
 
     if (t == SearchType.Notes or t == None) and model.notes_search:
         # query notes
-        hits = asymmetric.query(user_query, model.notes_search, device=device)
+        hits, entries = asymmetric.query(user_query, model.notes_search, device=device)
 
         # collate and return results
-        return asymmetric.collate_results(hits, model.notes_search.entries, results_count)
+        return asymmetric.collate_results(hits, entries, results_count)
 
     if (t == SearchType.Music or t == None) and model.music_search:
         # query music library
-        hits = asymmetric.query(user_query, model.music_search, device=device)
+        hits, entries = asymmetric.query(user_query, model.music_search, device=device)
 
         # collate and return results
-        return asymmetric.collate_results(hits, model.music_search.entries, results_count)
+        return asymmetric.collate_results(hits, entries, results_count)
 
     if (t == SearchType.Ledger or t == None) and model.ledger_search:
         # query transactions

--- a/tests/test_asymmetric_search.py
+++ b/tests/test_asymmetric_search.py
@@ -26,13 +26,13 @@ def test_asymmetric_search(content_config: ContentConfig, search_config: SearchC
     query = "How to git install application?"
 
     # Act
-    hits = asymmetric.query(
+    hits, entries = asymmetric.query(
         query,
         model = model.notes_search)
 
     results = asymmetric.collate_results(
         hits,
-        model.notes_search.entries,
+        entries,
         count=1)
 
     # Assert


### PR DESCRIPTION
## Issue
  - Explicit filtering was being done after search by the bi-encoder
     but before re-ranking by the cross-encoder

  - This limited the quality of results being returned for queries with explicit filters. 
     The bi-encoder returned results which were going to be excluded. 
     So the burden of improving those limited results post filtering was on the
     cross-encoder, by re-ranking the remaining results to best match the query

## Fix
  - Given that the entry and its embedding are at the same index in their respective lists. 
     We know which entries map to which embedding tensors.
     So we can run the filter for blocked, required words before the bi-encoder search. 
     And limit entries, embeddings being considered for the current query

## Result
  - Semantic search by the bi-encoder returns the most relevant results 
     for the query, knowing that the results aren't going to be filtered out after. 
     So the cross-encoder shoulders less of the burden of improving the results

## Corollary
  - This pre-filtering technique allows us to apply other explicit filters
     on entries relevant for the current query, before calling search
     - E.g limit search to entries within date/time specified in query